### PR TITLE
Fix Decursive skin, add Outfitter basic skin

### DIFF
--- a/pfUI-addonskinner.toc
+++ b/pfUI-addonskinner.toc
@@ -35,6 +35,7 @@ skins\LevelRange.lua
 skins\LoseControl.lua
 skins\ModifiedPowerAuras.lua
 skins\MTLove.lua
+skins\Outfitter.lua
 skins\pfQuest.lua
 skins\Possessions.lua
 skins\RABuffs.lua

--- a/skins/Decursive.lua
+++ b/skins/Decursive.lua
@@ -1,7 +1,7 @@
 pfUI.addonskinner:RegisterSkin("Decursive", function()
-  local penv = pfUI:GetEnvironment()
-  local hooksecurefunc = penv.hooksecurefunc
-  if pfUI and pfUI.api then
+  if pfUI and pfUI.api and pfUI_config then
+    local penv = pfUI:GetEnvironment()
+    local hooksecurefunc, CreateBackdrop, SkinButton, SkinCheckbox, SkinSlider = penv.hooksecurefunc, penv.CreateBackdrop, penv.SkinButton, penv.SkinCheckbox, penv.SkinSlider
     local frame_table = {
       DecursiveMainBar = {
         buttons = {"Priority", "Skip", "Options", "Hide"},
@@ -82,7 +82,7 @@ pfUI.addonskinner:RegisterSkin("Decursive", function()
       end
     end, 1)
     
-    local tooltip_alpha = tonumber(C.tooltip.alpha)
+    local tooltip_alpha = tonumber(pfUI_config.tooltip.alpha)
     CreateBackdrop(Dcr_Tooltip, nil, nil, tooltip_alpha)
     CreateBackdrop(DcrDisplay_Tooltip, nil, nil, tooltip_alpha)
     CreateBackdrop(Dcr_ScanningTooltip, nil, nil, tooltip_alpha)

--- a/skins/Outfitter.lua
+++ b/skins/Outfitter.lua
@@ -1,0 +1,23 @@
+pfUI.addonskinner:RegisterSkin("Outfitter", function()
+  local penv = pfUI:GetEnvironment()
+  local StripTextures, CreateBackdrop = penv.StripTextures, penv.CreateBackdrop
+
+  local Skin = function()
+    StripTextures(OutfitterCurrentOutfit, true, "BACKGROUND")
+    CreateBackdrop(OutfitterCurrentOutfit, nil, true, .75)
+    -- OutfitterCurrentOutfit:SetHeight(20)
+  end
+
+  if not OutfitterCurrentOutfit then
+    local orig_Outfitter_PEW = Outfitter_PlayerEnteringWorld
+
+    Outfitter_PlayerEnteringWorld = function(self, event)
+      orig_Outfitter_PEW(self, event)
+      Skin()
+    end
+  else
+    Skin()
+  end 
+
+  pfUI.addonskinner:UnregisterSkin("Outfitter")
+end)


### PR DESCRIPTION
As described here
https://github.com/mrrosh/pfUI-addonskinner/issues/3#issue-2988368381
Decursive wont load without this fixes.
Also Outfitter "current outfit" frame skinned.