### PR TITLE
add MouseOverSounds support

### DIFF
--- a/pfUI-addonskinner.toc
+++ b/pfUI-addonskinner.toc
@@ -34,6 +34,7 @@ skins\ItemRack.lua
 skins\LevelRange.lua
 skins\LoseControl.lua
 skins\ModifiedPowerAuras.lua
+skins\MouseOverSounds.lua
 skins\MTLove.lua
 skins\Outfitter.lua
 skins\pfQuest.lua

--- a/skins/MouseOverSounds.lua
+++ b/skins/MouseOverSounds.lua
@@ -1,0 +1,10 @@
+pfUI.addonskinner:RegisterSkin("MouseOverSounds", function()
+    local penv = pfUI:GetEnvironment()
+    local HookAddonOrVariable, SkinButton = penv.HookAddonOrVariable, penv.SkinButton
+
+    HookAddonOrVariable("mouseOverSounds", function()
+        SkinButton(GameMenuButtonMouseOverSoundsSettings)
+    end)
+
+    pfUI.addonskinner:UnregisterSkin("MouseOverSounds")
+end)


### PR DESCRIPTION
skin main menu button of MouseOverSounds addon
from
![p1](https://github.com/user-attachments/assets/7c77160b-a631-4cbd-bf2f-98f0b899603a)
to
![p2](https://github.com/user-attachments/assets/2d1216a6-f70e-45cf-97b1-444bd49ece0e)
